### PR TITLE
Add ApiSDK generator and update hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ openapi-gen generate [options]
 ```
 
 **Options:**
+
 - `-i, --input <path>` - Path to OpenAPI spec file (JSON/YAML) or URL (required)
 - `-o, --output <dir>` - Output directory for generated code (default: "./generated")
 - `--no-hooks` - Skip generating React Query hooks
@@ -102,6 +103,7 @@ openapi-gen init [options]
 ```
 
 **Options:**
+
 - `-d, --dir <directory>` - Directory to initialize (default: ".")
 
 ## Generated Code Structure
@@ -133,13 +135,13 @@ Each OpenAPI schema becomes a Zod schema with TypeScript types:
 
 ```typescript
 // generated/models/User.ts
-import { z } from 'zod';
+import { z } from "zod";
 
 export const UserSchema = z.object({
   id: z.string().uuid(),
   email: z.string().email(),
   name: z.string(),
-  role: z.enum(['admin', 'user']),
+  role: z.enum(["admin", "user"]),
   createdAt: z.string().datetime(),
 });
 
@@ -152,20 +154,20 @@ Endpoint classes extend the base client and provide type-safe methods:
 
 ```typescript
 // generated/endpoints/UsersApi.ts
-import { ApiClient } from '../ApiClient';
-import { UserSchema, User, CreateUserSchema, CreateUser } from '../models';
+import { ApiClient } from "../ApiClient";
+import { UserSchema, User, CreateUserSchema, CreateUser } from "../models";
 
 export class UsersApi extends ApiClient {
   getUsers(page?: number, limit?: number): Promise<User[]> {
-    return this.get('/users', z.array(UserSchema), {
-      queryParams: { page, limit }
+    return this.get("/users", z.array(UserSchema), {
+      queryParams: { page, limit },
     });
   }
 
   createUser(data: CreateUser): Promise<User> {
-    return this.post('/users', UserSchema, {
+    return this.post("/users", UserSchema, {
       body: data,
-      bodySchema: CreateUserSchema
+      bodySchema: CreateUserSchema,
     });
   }
 
@@ -181,22 +183,22 @@ Ready-to-use hooks for your React components:
 
 ```typescript
 // generated/hooks/Users.ts
-import { useQuery, useMutation } from '@tanstack/react-query';
-import { UsersApi } from '../endpoints/UsersApi';
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { ApiSDK } from "../ApiSDK";
 
-const usersApi = new UsersApi(process.env.REACT_APP_API_BASE_URL || '');
+const apiSDK = new ApiSDK(process.env.REACT_APP_API_BASE_URL || "");
 
 export function useGetUsers(page?: number, limit?: number) {
   return useQuery({
-    queryKey: ['getUsers', page, limit],
-    queryFn: () => usersApi.getUsers(page, limit),
+    queryKey: ["getUsers", page, limit],
+    queryFn: () => apiSDK.usersApi.getUsers(page, limit),
   });
 }
 
 export function useCreateUser() {
   return useMutation({
     mutationFn: (variables: { email: string; name: string; role?: string }) => {
-      return usersApi.createUser(variables);
+      return apiSDK.usersApi.createUser(variables);
     },
   });
 }
@@ -242,21 +244,21 @@ Ensure your `tsconfig.json` includes the generated code:
 You can extend the generated API client for custom functionality:
 
 ```typescript
-import { UsersApi } from './generated';
+import { UsersApi } from "./generated";
 
 class CustomUsersApi extends UsersApi {
   constructor(baseUrl: string, authToken: string) {
     super({
       baseUrl,
       headers: {
-        'Authorization': `Bearer ${authToken}`,
+        Authorization: `Bearer ${authToken}`,
       },
     });
   }
 
   // Add custom methods
   async getCurrentUser(): Promise<User> {
-    return this.getUserById('me');
+    return this.getUserById("me");
   }
 }
 ```
@@ -286,10 +288,10 @@ The generated client includes comprehensive error handling:
 
 ```typescript
 try {
-  const user = await usersApi.getUserById('123');
+  const user = await apiSDK.usersApi.getUserById("123");
 } catch (error) {
   if (error instanceof Error) {
-    console.error('API Error:', error.message);
+    console.error("API Error:", error.message);
     // Error message includes HTTP status and response details
   }
 }

--- a/src/generator/hooks-generator.test.ts
+++ b/src/generator/hooks-generator.test.ts
@@ -1,457 +1,565 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { HooksGenerator } from './hooks-generator'
-import { ParsedOperation } from '../utils/openapi-parser'
-import { GeneratedMethod } from './endpoint-generator'
+import { describe, it, expect, beforeEach } from "vitest";
+import { HooksGenerator } from "./hooks-generator";
+import { ParsedOperation } from "../utils/openapi-parser";
+import { GeneratedMethod } from "./endpoint-generator";
 
-describe('HooksGenerator', () => {
-  let generator: HooksGenerator
+describe("HooksGenerator", () => {
+  let generator: HooksGenerator;
 
   beforeEach(() => {
-    generator = new HooksGenerator()
-  })
+    generator = new HooksGenerator();
+  });
 
-  describe('generateHooksForTag', () => {
-    it('should generate hooks file for query operations', () => {
-      const operations: ParsedOperation[] = [{
-        operationId: 'getUsers',
-        method: 'GET',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }]
-
-      const methods: GeneratedMethod[] = [{
-        name: 'getUsers',
-        parameters: [],
-        returnType: 'Promise<User[]>',
-        httpMethod: 'GET',
-        path: '/users',
-        responseSchema: 'UserArraySchema'
-      }]
-
-      const result = generator.generateHooksForTag(operations, 'users', 'UsersApi', methods)
-
-      expect(result.tag).toBe('users')
-      expect(result.hooks).toHaveLength(1)
-      expect(result.hooks[0].hookType).toBe('query')
-      expect(result.content).toContain('export function useGetUsers(')
-      expect(result.content).toContain('useQuery({')
-      expect(result.content).toContain('const usersApi = new UsersApi')
-    })
-
-    it('should generate hooks file for mutation operations', () => {
-      const operations: ParsedOperation[] = [{
-        operationId: 'createUser',
-        method: 'POST',
-        path: '/users',
-        responses: { '201': { description: 'Created' } }
-      }]
-
-      const methods: GeneratedMethod[] = [{
-        name: 'createUser',
-        parameters: [{
-          name: 'data',
-          type: 'CreateUser',
-          required: true,
-          location: 'body'
-        }],
-        returnType: 'Promise<User>',
-        httpMethod: 'POST',
-        path: '/users',
-        responseSchema: 'UserSchema'
-      }]
-
-      const result = generator.generateHooksForTag(operations, 'users', 'UsersApi', methods)
-
-      expect(result.hooks[0].hookType).toBe('mutation')
-      expect(result.content).toContain('export function useCreateUser(')
-      expect(result.content).toContain('useMutation({')
-    })
-  })
-
-  describe('query hook generation', () => {
-    it('should generate query hook with required parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'getUserById',
-        method: 'GET',
-        path: '/users/{id}',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getUserById',
-        parameters: [{
-          name: 'id',
-          type: 'string',
-          required: true,
-          location: 'path'
-        }],
-        returnType: 'Promise<User>',
-        httpMethod: 'GET',
-        path: '/users/{id}',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-
-      expect(result.content).toContain('useGetUserById(id: string')
-      expect(result.content).toContain('queryKey: ["getUserById", id]')
-      expect(result.content).toContain('enabled: id != null')
-      expect(result.content).toContain('usersApi.getUserById(id)')
-    })
-
-    it('should generate query hook with optional parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'getUsers',
-        method: 'GET',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getUsers',
-        parameters: [{
-          name: 'limit',
-          type: 'number',
-          required: false,
-          location: 'query'
-        }],
-        returnType: 'Promise<User[]>',
-        httpMethod: 'GET',
-        path: '/users',
-        responseSchema: 'UserArraySchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-
-      expect(result.content).toContain('options?: { limit?: number }')
-      expect(result.content).toContain('usersApi.getUsers(options?.limit)')
-      expect(result.content).toContain('...queryOptions')
-    })
-
-    it('should generate query hook without parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'getHealth',
-        method: 'GET',
-        path: '/health',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getHealth',
-        parameters: [],
-        returnType: 'Promise<unknown>',
-        httpMethod: 'GET',
-        path: '/health',
-        responseSchema: 'z.unknown()'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'health', 'HealthApi', [method])
-
-      expect(result.content).toContain('useGetHealth(queryOptions?:')
-      expect(result.content).toContain('queryKey: ["getHealth"]')
-      expect(result.content).toContain('healthApi.getHealth()')
-    })
-  })
-
-  describe('mutation hook generation', () => {
-    it('should generate mutation hook with parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'createUser',
-        method: 'POST',
-        path: '/users',
-        responses: { '201': { description: 'Created' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'createUser',
-        parameters: [{
-          name: 'data',
-          type: 'CreateUser',
-          required: true,
-          location: 'body'
-        }],
-        returnType: 'Promise<User>',
-        httpMethod: 'POST',
-        path: '/users',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-
-      expect(result.content).toContain('useCreateUser(')
-      expect(result.content).toContain('UseMutationOptions<User, Error, { data: CreateUser }>')
-      expect(result.content).toContain('variables: { data: CreateUser }')
-      expect(result.content).toContain('usersApi.createUser(variables.data)')
-    })
-
-    it('should generate mutation hook without parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'logout',
-        method: 'POST',
-        path: '/auth/logout',
-        responses: { '204': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'logout',
-        parameters: [],
-        returnType: 'Promise<void>',
-        httpMethod: 'POST',
-        path: '/auth/logout',
-        responseSchema: 'z.void()'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'auth', 'AuthApi', [method])
-
-      expect(result.content).toContain('useLogout(')
-      expect(result.content).toContain('variables: void')
-      expect(result.content).toContain('authApi.logout()')
-    })
-
-    it('should generate mutation hook with multiple parameters', () => {
-      const operation: ParsedOperation = {
-        operationId: 'updateUser',
-        method: 'PUT',
-        path: '/users/{id}',
-        responses: { '200': { description: 'Updated' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'updateUser',
-        parameters: [
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-            location: 'path'
-          },
-          {
-            name: 'data',
-            type: 'UpdateUser',
-            required: true,
-            location: 'body'
-          }
-        ],
-        returnType: 'Promise<User>',
-        httpMethod: 'PUT',
-        path: '/users/{id}',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-
-      expect(result.content).toContain('{ id: string; data: UpdateUser }')
-      expect(result.content).toContain('usersApi.updateUser(variables.id, variables.data)')
-    })
-  })
-
-  describe('hook name generation', () => {
-    it('should use operationId when available', () => {
-      const operation: ParsedOperation = {
-        operationId: 'getUserProfile',
-        method: 'GET',
-        path: '/users/profile',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getUserProfile',
-        parameters: [],
-        returnType: 'Promise<User>',
-        httpMethod: 'GET',
-        path: '/users/profile',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.content).toContain('useGetUserProfile(')
-    })
-
-    it('should generate hook name from method and path', () => {
-      const operation: ParsedOperation = {
-        method: 'POST',
-        path: '/users/settings',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'postUsersSettings',
-        parameters: [],
-        returnType: 'Promise<void>',
-        httpMethod: 'POST',
-        path: '/users/settings',
-        responseSchema: 'z.void()'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.content).toContain('usePostUsersSettings(')
-    })
-
-    it('should handle camelCase conversion', () => {
-      const operation: ParsedOperation = {
-        operationId: 'get-user-profile',
-        method: 'GET',
-        path: '/users/profile',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getUserProfile',
-        parameters: [],
-        returnType: 'Promise<User>',
-        httpMethod: 'GET',
-        path: '/users/profile',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.content).toContain('useGetUserProfile(')
-    })
-  })
-
-  describe('operation type detection', () => {
-    it('should identify GET as query operation', () => {
-      const operation: ParsedOperation = {
-        method: 'GET',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'getUsers',
-        parameters: [],
-        returnType: 'Promise<User[]>',
-        httpMethod: 'GET',
-        path: '/users',
-        responseSchema: 'UserArraySchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.hooks[0].hookType).toBe('query')
-    })
-
-    it('should identify HEAD as query operation', () => {
-      const operation: ParsedOperation = {
-        method: 'HEAD',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'headUsers',
-        parameters: [],
-        returnType: 'Promise<void>',
-        httpMethod: 'HEAD',
-        path: '/users',
-        responseSchema: 'z.void()'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.hooks[0].hookType).toBe('query')
-    })
-
-    it('should identify OPTIONS as query operation', () => {
-      const operation: ParsedOperation = {
-        method: 'OPTIONS',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'optionsUsers',
-        parameters: [],
-        returnType: 'Promise<void>',
-        httpMethod: 'OPTIONS',
-        path: '/users',
-        responseSchema: 'z.void()'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.hooks[0].hookType).toBe('query')
-    })
-
-    it('should identify POST as mutation operation', () => {
-      const operation: ParsedOperation = {
-        method: 'POST',
-        path: '/users',
-        responses: { '201': { description: 'Created' } }
-      }
-
-      const method: GeneratedMethod = {
-        name: 'createUser',
-        parameters: [],
-        returnType: 'Promise<User>',
-        httpMethod: 'POST',
-        path: '/users',
-        responseSchema: 'UserSchema'
-      }
-
-      const result = generator.generateHooksForTag([operation], 'users', 'UsersApi', [method])
-      expect(result.hooks[0].hookType).toBe('mutation')
-    })
-  })
-
-  describe('generateQueryKeys', () => {
-    it('should generate query keys for operations with parameters', () => {
-      const operations: ParsedOperation[] = [{
-        operationId: 'getUserById',
-        method: 'GET',
-        path: '/users/{id}',
-        responses: { '200': { description: 'Success' } }
-      }]
-
-      const result = generator.generateQueryKeys(operations)
-
-      expect(result).toContain('export const useGetUserByIdKey = (id: string | number)')
-      expect(result).toContain('["getUserById", id] as const')
-    })
-
-    it('should generate query keys for operations without parameters', () => {
-      const operations: ParsedOperation[] = [{
-        operationId: 'getUsers',
-        method: 'GET',
-        path: '/users',
-        responses: { '200': { description: 'Success' } }
-      }]
-
-      const result = generator.generateQueryKeys(operations)
-
-      expect(result).toContain('export const useGetUsersKey = ()')
-      expect(result).toContain('["getUsers"] as const')
-    })
-
-    it('should only include query operations', () => {
+  describe("generateHooksForTag", () => {
+    it("should generate hooks file for query operations", () => {
       const operations: ParsedOperation[] = [
         {
-          operationId: 'getUsers',
-          method: 'GET',
-          path: '/users',
-          responses: { '200': { description: 'Success' } }
+          operationId: "getUsers",
+          method: "GET",
+          path: "/users",
+          responses: { "200": { description: "Success" } },
+        },
+      ];
+
+      const methods: GeneratedMethod[] = [
+        {
+          name: "getUsers",
+          parameters: [],
+          returnType: "Promise<User[]>",
+          httpMethod: "GET",
+          path: "/users",
+          responseSchema: "UserArraySchema",
+        },
+      ];
+
+      const result = generator.generateHooksForTag(
+        operations,
+        "users",
+        "UsersApi",
+        methods,
+      );
+
+      expect(result.tag).toBe("users");
+      expect(result.hooks).toHaveLength(1);
+      expect(result.hooks[0].hookType).toBe("query");
+      expect(result.content).toContain("export function useGetUsers(");
+      expect(result.content).toContain("useQuery({");
+      expect(result.content).toContain("const apiSDK = new ApiSDK");
+    });
+
+    it("should generate hooks file for mutation operations", () => {
+      const operations: ParsedOperation[] = [
+        {
+          operationId: "createUser",
+          method: "POST",
+          path: "/users",
+          responses: { "201": { description: "Created" } },
+        },
+      ];
+
+      const methods: GeneratedMethod[] = [
+        {
+          name: "createUser",
+          parameters: [
+            {
+              name: "data",
+              type: "CreateUser",
+              required: true,
+              location: "body",
+            },
+          ],
+          returnType: "Promise<User>",
+          httpMethod: "POST",
+          path: "/users",
+          responseSchema: "UserSchema",
+        },
+      ];
+
+      const result = generator.generateHooksForTag(
+        operations,
+        "users",
+        "UsersApi",
+        methods,
+      );
+
+      expect(result.hooks[0].hookType).toBe("mutation");
+      expect(result.content).toContain("export function useCreateUser(");
+      expect(result.content).toContain("useMutation({");
+    });
+  });
+
+  describe("query hook generation", () => {
+    it("should generate query hook with required parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "getUserById",
+        method: "GET",
+        path: "/users/{id}",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getUserById",
+        parameters: [
+          {
+            name: "id",
+            type: "string",
+            required: true,
+            location: "path",
+          },
+        ],
+        returnType: "Promise<User>",
+        httpMethod: "GET",
+        path: "/users/{id}",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+
+      expect(result.content).toContain("useGetUserById(id: string");
+      expect(result.content).toContain('queryKey: ["getUserById", id]');
+      expect(result.content).toContain("enabled: id != null");
+      expect(result.content).toContain("apiSDK.usersApi.getUserById(id)");
+    });
+
+    it("should generate query hook with optional parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "getUsers",
+        method: "GET",
+        path: "/users",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getUsers",
+        parameters: [
+          {
+            name: "limit",
+            type: "number",
+            required: false,
+            location: "query",
+          },
+        ],
+        returnType: "Promise<User[]>",
+        httpMethod: "GET",
+        path: "/users",
+        responseSchema: "UserArraySchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+
+      expect(result.content).toContain("options?: { limit?: number }");
+      expect(result.content).toContain(
+        "apiSDK.usersApi.getUsers(options?.limit)",
+      );
+      expect(result.content).toContain("...queryOptions");
+    });
+
+    it("should generate query hook without parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "getHealth",
+        method: "GET",
+        path: "/health",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getHealth",
+        parameters: [],
+        returnType: "Promise<unknown>",
+        httpMethod: "GET",
+        path: "/health",
+        responseSchema: "z.unknown()",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "health",
+        "HealthApi",
+        [method],
+      );
+
+      expect(result.content).toContain("export function useGetHealth(");
+      expect(result.content).toContain("queryOptions?: Omit<UseQueryOptions");
+      expect(result.content).toContain('queryKey: ["getHealth"]');
+      expect(result.content).toContain("apiSDK.healthApi.getHealth()");
+    });
+  });
+
+  describe("mutation hook generation", () => {
+    it("should generate mutation hook with parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "createUser",
+        method: "POST",
+        path: "/users",
+        responses: { "201": { description: "Created" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "createUser",
+        parameters: [
+          {
+            name: "data",
+            type: "CreateUser",
+            required: true,
+            location: "body",
+          },
+        ],
+        returnType: "Promise<User>",
+        httpMethod: "POST",
+        path: "/users",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+
+      expect(result.content).toContain("useCreateUser(");
+      expect(result.content).toContain(
+        "UseMutationOptions<User, Error, { data: CreateUser }>",
+      );
+      expect(result.content).toContain("variables: { data: CreateUser }");
+      expect(result.content).toContain(
+        "apiSDK.usersApi.createUser(variables.data)",
+      );
+    });
+
+    it("should generate mutation hook without parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "logout",
+        method: "POST",
+        path: "/auth/logout",
+        responses: { "204": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "logout",
+        parameters: [],
+        returnType: "Promise<void>",
+        httpMethod: "POST",
+        path: "/auth/logout",
+        responseSchema: "z.void()",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "auth",
+        "AuthApi",
+        [method],
+      );
+
+      expect(result.content).toContain("useLogout(");
+      expect(result.content).toContain(
+        "mutationOptions?: Omit<UseMutationOptions<void, Error, void>",
+      );
+      expect(result.content).toContain("apiSDK.authApi.logout()");
+    });
+
+    it("should generate mutation hook with multiple parameters", () => {
+      const operation: ParsedOperation = {
+        operationId: "updateUser",
+        method: "PUT",
+        path: "/users/{id}",
+        responses: { "200": { description: "Updated" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "updateUser",
+        parameters: [
+          {
+            name: "id",
+            type: "string",
+            required: true,
+            location: "path",
+          },
+          {
+            name: "data",
+            type: "UpdateUser",
+            required: true,
+            location: "body",
+          },
+        ],
+        returnType: "Promise<User>",
+        httpMethod: "PUT",
+        path: "/users/{id}",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+
+      expect(result.content).toContain("{ id: string; data: UpdateUser }");
+      expect(result.content).toContain(
+        "apiSDK.usersApi.updateUser(variables.id, variables.data)",
+      );
+    });
+  });
+
+  describe("hook name generation", () => {
+    it("should use operationId when available", () => {
+      const operation: ParsedOperation = {
+        operationId: "getUserProfile",
+        method: "GET",
+        path: "/users/profile",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getUserProfile",
+        parameters: [],
+        returnType: "Promise<User>",
+        httpMethod: "GET",
+        path: "/users/profile",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.content).toContain("useGetUserProfile(");
+    });
+
+    it("should generate hook name from method and path", () => {
+      const operation: ParsedOperation = {
+        method: "POST",
+        path: "/users/settings",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "postUsersSettings",
+        parameters: [],
+        returnType: "Promise<void>",
+        httpMethod: "POST",
+        path: "/users/settings",
+        responseSchema: "z.void()",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.content).toContain("usePostUsersSettings(");
+    });
+
+    it("should handle camelCase conversion", () => {
+      const operation: ParsedOperation = {
+        operationId: "get-user-profile",
+        method: "GET",
+        path: "/users/profile",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getUserProfile",
+        parameters: [],
+        returnType: "Promise<User>",
+        httpMethod: "GET",
+        path: "/users/profile",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.content).toContain("useGetUserProfile(");
+    });
+  });
+
+  describe("operation type detection", () => {
+    it("should identify GET as query operation", () => {
+      const operation: ParsedOperation = {
+        method: "GET",
+        path: "/users",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "getUsers",
+        parameters: [],
+        returnType: "Promise<User[]>",
+        httpMethod: "GET",
+        path: "/users",
+        responseSchema: "UserArraySchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.hooks[0].hookType).toBe("query");
+    });
+
+    it("should identify HEAD as query operation", () => {
+      const operation: ParsedOperation = {
+        method: "HEAD",
+        path: "/users",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "headUsers",
+        parameters: [],
+        returnType: "Promise<void>",
+        httpMethod: "HEAD",
+        path: "/users",
+        responseSchema: "z.void()",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.hooks[0].hookType).toBe("query");
+    });
+
+    it("should identify OPTIONS as query operation", () => {
+      const operation: ParsedOperation = {
+        method: "OPTIONS",
+        path: "/users",
+        responses: { "200": { description: "Success" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "optionsUsers",
+        parameters: [],
+        returnType: "Promise<void>",
+        httpMethod: "OPTIONS",
+        path: "/users",
+        responseSchema: "z.void()",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.hooks[0].hookType).toBe("query");
+    });
+
+    it("should identify POST as mutation operation", () => {
+      const operation: ParsedOperation = {
+        method: "POST",
+        path: "/users",
+        responses: { "201": { description: "Created" } },
+      };
+
+      const method: GeneratedMethod = {
+        name: "createUser",
+        parameters: [],
+        returnType: "Promise<User>",
+        httpMethod: "POST",
+        path: "/users",
+        responseSchema: "UserSchema",
+      };
+
+      const result = generator.generateHooksForTag(
+        [operation],
+        "users",
+        "UsersApi",
+        [method],
+      );
+      expect(result.hooks[0].hookType).toBe("mutation");
+    });
+  });
+
+  describe("generateQueryKeys", () => {
+    it("should generate query keys for operations with parameters", () => {
+      const operations: ParsedOperation[] = [
+        {
+          operationId: "getUserById",
+          method: "GET",
+          path: "/users/{id}",
+          responses: { "200": { description: "Success" } },
+        },
+      ];
+
+      const result = generator.generateQueryKeys(operations);
+
+      expect(result).toContain(
+        "export const useGetUserByIdKey = (id: string | number)",
+      );
+      expect(result).toContain('["getUserById", id] as const');
+    });
+
+    it("should generate query keys for operations without parameters", () => {
+      const operations: ParsedOperation[] = [
+        {
+          operationId: "getUsers",
+          method: "GET",
+          path: "/users",
+          responses: { "200": { description: "Success" } },
+        },
+      ];
+
+      const result = generator.generateQueryKeys(operations);
+
+      expect(result).toContain("export const useGetUsersKey = ()");
+      expect(result).toContain('["getUsers"] as const');
+    });
+
+    it("should only include query operations", () => {
+      const operations: ParsedOperation[] = [
+        {
+          operationId: "getUsers",
+          method: "GET",
+          path: "/users",
+          responses: { "200": { description: "Success" } },
         },
         {
-          operationId: 'createUser',
-          method: 'POST',
-          path: '/users',
-          responses: { '201': { description: 'Created' } }
-        }
-      ]
+          operationId: "createUser",
+          method: "POST",
+          path: "/users",
+          responses: { "201": { description: "Created" } },
+        },
+      ];
 
-      const result = generator.generateQueryKeys(operations)
+      const result = generator.generateQueryKeys(operations);
 
-      expect(result).toContain('useGetUsersKey')
-      expect(result).not.toContain('useCreateUserKey')
-    })
-  })
+      expect(result).toContain("useGetUsersKey");
+      expect(result).not.toContain("useCreateUserKey");
+    });
+  });
 
-  describe('generateIndexFile', () => {
-    it('should generate index file with exports', () => {
-      const tags = ['users', 'posts', 'auth']
-      const result = generator.generateIndexFile(tags)
+  describe("generateIndexFile", () => {
+    it("should generate index file with exports", () => {
+      const tags = ["users", "posts", "auth"];
+      const result = generator.generateIndexFile(tags);
 
-      expect(result).toContain('export * from "./users";')
-      expect(result).toContain('export * from "./posts";')
-      expect(result).toContain('export * from "./auth";')
-      expect(result).toContain('export * from "./queryKeys";')
-    })
-  })
-})
+      expect(result).toContain('export * from "./users";');
+      expect(result).toContain('export * from "./posts";');
+      expect(result).toContain('export * from "./auth";');
+      expect(result).toContain('export * from "./queryKeys";');
+    });
+  });
+});

--- a/src/generator/hooks-generator.ts
+++ b/src/generator/hooks-generator.ts
@@ -1,11 +1,11 @@
-import { ParsedOperation } from '../utils/openapi-parser';
-import { GeneratedMethod } from './endpoint-generator';
+import { ParsedOperation } from "../utils/openapi-parser";
+import { GeneratedMethod } from "./endpoint-generator";
 
 export interface GeneratedHook {
   name: string;
   content: string;
   operation: ParsedOperation;
-  hookType: 'query' | 'mutation';
+  hookType: "query" | "mutation";
 }
 
 export interface GeneratedHooksFile {
@@ -16,25 +16,21 @@ export interface GeneratedHooksFile {
 
 export class HooksGenerator {
   generateHooksForTag(
-    operations: ParsedOperation[], 
-    tag: string, 
+    operations: ParsedOperation[],
+    tag: string,
     className: string,
-    methods: GeneratedMethod[]
+    methods: GeneratedMethod[],
   ): GeneratedHooksFile {
-    const hooks = operations.map((operation, index) => 
-      this.generateHook(operation, className, methods[index])
+    const hooks = operations.map((operation, index) =>
+      this.generateHook(operation, className, methods[index]),
     );
 
     const imports = this.generateImports(className, hooks);
-    const hookContents = hooks.map(hook => hook.content).join('\n\n');
-
-    // Generate proper API instance name from className
-    const baseName = className.replace('Api', '');
-    const apiInstanceName = this.toCamelCase(baseName) + 'Api';
+    const hookContents = hooks.map((hook) => hook.content).join("\n\n");
 
     const content = `${imports}
 
-const ${apiInstanceName} = new ${className}(process.env.REACT_APP_API_BASE_URL || '');
+const apiSDK = new ApiSDK(process.env.REACT_APP_API_BASE_URL || '');
 
 ${hookContents}
 `;
@@ -47,14 +43,14 @@ ${hookContents}
   }
 
   private generateHook(
-    operation: ParsedOperation, 
-    className: string, 
-    method: GeneratedMethod
+    operation: ParsedOperation,
+    className: string,
+    method: GeneratedMethod,
   ): GeneratedHook {
     const isQuery = this.isQueryOperation(operation.method);
     const hookName = this.generateHookName(operation, isQuery);
-    
-    const content = isQuery 
+
+    const content = isQuery
       ? this.generateQueryHook(operation, method, className)
       : this.generateMutationHook(operation, method, className);
 
@@ -62,78 +58,91 @@ ${hookContents}
       name: hookName,
       content,
       operation,
-      hookType: isQuery ? 'query' : 'mutation',
+      hookType: isQuery ? "query" : "mutation",
     };
   }
 
   private isQueryOperation(method: string): boolean {
-    return ['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase());
+    return ["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase());
   }
 
-  private generateHookName(operation: ParsedOperation, isQuery: boolean): string {
-    const prefix = isQuery ? 'use' : 'use';
-    
+  private generateHookName(
+    operation: ParsedOperation,
+    isQuery: boolean,
+  ): string {
+    const prefix = isQuery ? "use" : "use";
+
     if (operation.operationId) {
       return prefix + this.toPascalCase(operation.operationId);
     }
 
     const method = operation.method.toLowerCase();
     const pathParts = operation.path
-      .split('/')
-      .filter(part => part && !part.startsWith('{') && !part.startsWith(':'))
-      .map(part => this.toPascalCase(part.replace(/[^a-zA-Z0-9]/g, '')));
+      .split("/")
+      .filter((part) => part && !part.startsWith("{") && !part.startsWith(":"))
+      .map((part) => this.toPascalCase(part.replace(/[^a-zA-Z0-9]/g, "")));
 
-    return prefix + this.toPascalCase(method) + pathParts.join('');
+    return prefix + this.toPascalCase(method) + pathParts.join("");
   }
 
   private generateQueryHook(
     operation: ParsedOperation,
     method: GeneratedMethod,
-    className: string
+    className: string,
   ): string {
     const hookName = this.generateHookName(operation, true);
     const methodName = method.name;
-    const baseName = className.replace('Api', '');
-    const apiInstance = this.toCamelCase(baseName) + 'Api';
-    
+    const baseName = className.replace("Api", "");
+    const apiInstance = "apiSDK." + this.toCamelCase(baseName) + "Api";
+
     // Separate required and optional parameters
-    const requiredParams = method.parameters.filter(p => p.required);
-    const optionalParams = method.parameters.filter(p => !p.required);
-    
+    const requiredParams = method.parameters.filter((p) => p.required);
+    const optionalParams = method.parameters.filter((p) => !p.required);
+
     // Generate function parameters
     const functionParams: string[] = [];
-    
+
     // Add required parameters
-    requiredParams.forEach(param => {
+    requiredParams.forEach((param) => {
       functionParams.push(`${param.name}: ${param.type}`);
     });
-    
+
     // Add optional parameters as an options object
     if (optionalParams.length > 0) {
-      const optionalParamsType = optionalParams.map(p => 
-        `${p.name}?: ${p.type}`
-      ).join('; ');
+      const optionalParamsType = optionalParams
+        .map((p) => `${p.name}?: ${p.type}`)
+        .join("; ");
       functionParams.push(`options?: { ${optionalParamsType} }`);
     }
 
     // Add React Query options
-    const returnType = method.returnType.replace('Promise<', '').replace('>', '');
-    functionParams.push(`queryOptions?: Omit<UseQueryOptions<${returnType}, Error>, "queryKey" | "queryFn">`);
+    const returnType = method.returnType
+      .replace("Promise<", "")
+      .replace(">", "");
+    functionParams.push(
+      `queryOptions?: Omit<UseQueryOptions<${returnType}, Error>, "queryKey" | "queryFn">`,
+    );
 
     // Generate query key - include all parameters that affect the query
-    const allParams = [...requiredParams.map(p => p.name), ...optionalParams.map(p => `options?.${p.name}`)];
-    const queryKey = allParams.length > 0 
-      ? `[${JSON.stringify(methodName)}, ${allParams.join(', ')}]`
-      : `[${JSON.stringify(methodName)}]`;
+    const allParams = [
+      ...requiredParams.map((p) => p.name),
+      ...optionalParams.map((p) => `options?.${p.name}`),
+    ];
+    const queryKey =
+      allParams.length > 0
+        ? `[${JSON.stringify(methodName)}, ${allParams.join(", ")}]`
+        : `[${JSON.stringify(methodName)}]`;
 
     // Generate function call parameters
-    const callParams = method.parameters.map(p => {
-      if (p.required) {
-        return p.name;
-      } else {
-        return `options?.${p.name}`;
-      }
-    }).join(', ');
+    const callParams = method.parameters
+      .map((p) => {
+        if (p.required) {
+          return p.name;
+        } else {
+          return `options?.${p.name}`;
+        }
+      })
+      .join(", ");
 
     // Handle queries with no parameters
     if (method.parameters.length === 0) {
@@ -149,11 +158,12 @@ ${hookContents}
     }
 
     // Generate enabled condition for required parameters
-    const enabledCondition = requiredParams.length > 0
-      ? `enabled: ${requiredParams.map(p => `${p.name} != null`).join(' && ')}, ...queryOptions`
-      : '...queryOptions';
+    const enabledCondition =
+      requiredParams.length > 0
+        ? `enabled: ${requiredParams.map((p) => `${p.name} != null`).join(" && ")}, ...queryOptions`
+        : "...queryOptions";
 
-    return `export function ${hookName}(${functionParams.join(', ')}) {
+    return `export function ${hookName}(${functionParams.join(", ")}) {
   return useQuery({
     queryKey: ${queryKey},
     queryFn: () => ${apiInstance}.${methodName}(${callParams}),
@@ -165,24 +175,25 @@ ${hookContents}
   private generateMutationHook(
     operation: ParsedOperation,
     method: GeneratedMethod,
-    className: string
+    className: string,
   ): string {
     const hookName = this.generateHookName(operation, false);
     const methodName = method.name;
-    const baseName = className.replace('Api', '');
-    const apiInstance = this.toCamelCase(baseName) + 'Api';
-    
+    const baseName = className.replace("Api", "");
+    const apiInstance = "apiSDK." + this.toCamelCase(baseName) + "Api";
+
     // For mutations, we typically pass all parameters as a single object
-    const parameterTypes = method.parameters.map(p => {
-      const optional = !p.required ? '?' : '';
+    const parameterTypes = method.parameters.map((p) => {
+      const optional = !p.required ? "?" : "";
       return `${p.name}${optional}: ${p.type}`;
     });
 
-    const variablesType = parameterTypes.length > 0 
-      ? `{ ${parameterTypes.join('; ')} }`
-      : 'void';
+    const variablesType =
+      parameterTypes.length > 0 ? `{ ${parameterTypes.join("; ")} }` : "void";
 
-    const returnType = method.returnType.replace('Promise<', '').replace('>', '');
+    const returnType = method.returnType
+      .replace("Promise<", "")
+      .replace(">", "");
 
     // Handle the case where there are no parameters
     if (parameterTypes.length === 0) {
@@ -208,43 +219,56 @@ ${hookContents}
 }`;
   }
 
-  private generateMutationCall(method: GeneratedMethod, apiInstance: string): string {
+  private generateMutationCall(
+    method: GeneratedMethod,
+    apiInstance: string,
+  ): string {
     if (method.parameters.length === 0) {
       return `return ${apiInstance}.${method.name}();`;
     }
 
     // Handle destructuring for cleaner code
-    const paramNames = method.parameters.map(p => {
+    const paramNames = method.parameters.map((p) => {
       if (p.required) {
         return `variables.${p.name}`;
       } else {
         return `variables.${p.name}`;
       }
     });
-    
-    return `return ${apiInstance}.${method.name}(${paramNames.join(', ')});`;
+
+    return `return ${apiInstance}.${method.name}(${paramNames.join(", ")});`;
   }
 
-  private generateImports(className: string, hooks: GeneratedHook[]): string {
+  private generateImports(_className: string, hooks: GeneratedHook[]): string {
     const imports = [
       'import { useQuery, useMutation } from "@tanstack/react-query";',
       'import type { UseQueryOptions, UseMutationOptions } from "@tanstack/react-query";',
-      `import { ${className} } from "../endpoints/${className}";`
+      'import { ApiSDK } from "../ApiSDK";',
     ];
 
     // Collect all types used in hooks (excluding primitive types)
     const types = new Set<string>();
-    hooks.forEach(hook => {
+    hooks.forEach((hook) => {
       // Extract types from the hook content
       const returnTypeMatches = hook.content.match(/UseQueryOptions<([^,>]+)/g);
       if (returnTypeMatches) {
-        returnTypeMatches.forEach(match => {
-          const type = match.replace('UseQueryOptions<', '');
+        returnTypeMatches.forEach((match) => {
+          const type = match.replace("UseQueryOptions<", "");
           // Only import non-primitive types and exclude 'unknown', 'Error'
-          if (type && 
-              !['unknown', 'string', 'number', 'boolean', 'void', 'Error', 'any'].includes(type) &&
-              !type.includes('[]') && 
-              !type.startsWith('z.')) {
+          if (
+            type &&
+            ![
+              "unknown",
+              "string",
+              "number",
+              "boolean",
+              "void",
+              "Error",
+              "any",
+            ].includes(type) &&
+            !type.includes("[]") &&
+            !type.startsWith("z.")
+          ) {
             types.add(type);
           }
         });
@@ -253,50 +277,62 @@ ${hookContents}
 
     if (types.size > 0) {
       const sortedTypes = Array.from(types).sort();
-      imports.push(`import type { ${sortedTypes.join(', ')} } from "../models";`);
+      imports.push(
+        `import type { ${sortedTypes.join(", ")} } from "../models";`,
+      );
     }
 
-    return imports.join('\n');
+    return imports.join("\n");
   }
 
   private toCamelCase(str: string): string {
     // Convert PascalCase to camelCase by lowercasing first letter, then handle kebab/snake case
     const pascalToCamel = str.charAt(0).toLowerCase() + str.slice(1);
-    return pascalToCamel.replace(/[-_]([a-z])/g, (_, char) => char.toUpperCase());
+    return pascalToCamel.replace(/[-_]([a-z])/g, (_, char) =>
+      char.toUpperCase(),
+    );
   }
 
   private toPascalCase(str: string): string {
-    return str.replace(/[-_]([a-z])/g, (_, char) => char.toUpperCase())
-              .replace(/^[a-z]/, char => char.toUpperCase());
+    return str
+      .replace(/[-_]([a-z])/g, (_, char) => char.toUpperCase())
+      .replace(/^[a-z]/, (char) => char.toUpperCase());
   }
 
   generateQueryKeys(operations: ParsedOperation[]): string {
-    const queryOperations = operations.filter(op => this.isQueryOperation(op.method));
-    
-    const keyFunctions = queryOperations.map(operation => {
+    const queryOperations = operations.filter((op) =>
+      this.isQueryOperation(op.method),
+    );
+
+    const keyFunctions = queryOperations.map((operation) => {
       const hookName = this.generateHookName(operation, true);
-      const methodName = operation.operationId || `${operation.method.toLowerCase()}${operation.path}`;
-      
+      const methodName =
+        operation.operationId ||
+        `${operation.method.toLowerCase()}${operation.path}`;
+
       // Extract path parameters
-      const pathParams = (operation.path.match(/\{([^}]+)\}/g) || [])
-        .map(match => match.slice(1, -1));
-      
+      const pathParams = (operation.path.match(/\{([^}]+)\}/g) || []).map(
+        (match) => match.slice(1, -1),
+      );
+
       if (pathParams.length > 0) {
-        const params = pathParams.map(param => `${param}: string | number`).join(', ');
-        return `export const ${hookName}Key = (${params}) => [${JSON.stringify(methodName)}, ${pathParams.join(', ')}] as const;`;
+        const params = pathParams
+          .map((param) => `${param}: string | number`)
+          .join(", ");
+        return `export const ${hookName}Key = (${params}) => [${JSON.stringify(methodName)}, ${pathParams.join(", ")}] as const;`;
       } else {
         return `export const ${hookName}Key = () => [${JSON.stringify(methodName)}] as const;`;
       }
     });
 
     return `// Query key factory functions
-${keyFunctions.join('\n\n')}
+${keyFunctions.join("\n\n")}
 `;
   }
 
   generateIndexFile(tags: string[]): string {
-    const exports = tags.map(tag => `export * from "./${tag}";`);
+    const exports = tags.map((tag) => `export * from "./${tag}";`);
     exports.push('export * from "./queryKeys";');
-    return exports.join('\n') + '\n';
+    return exports.join("\n") + "\n";
   }
 }

--- a/src/generator/index.test.ts
+++ b/src/generator/index.test.ts
@@ -1,374 +1,476 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { CodeGenerator, GeneratorConfig } from './index'
-import * as fs from 'fs-extra'
-import * as path from 'path'
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { CodeGenerator, GeneratorConfig } from "./index";
+import * as fs from "fs-extra";
+import * as path from "path";
 
 // Mock fs-extra
-vi.mock('fs-extra', () => ({
+vi.mock("fs-extra", () => ({
   ensureDir: vi.fn(),
   writeFile: vi.fn(),
   readFile: vi.fn(),
   writeJSON: vi.fn(),
   readJSON: vi.fn(),
-  pathExists: vi.fn()
-}))
+  pathExists: vi.fn(),
+}));
 
-vi.mock('prettier', () => ({
-  format: vi.fn((code) => code) // Return code as-is for testing
-}))
+vi.mock("prettier", () => ({
+  format: vi.fn((code) => code), // Return code as-is for testing
+}));
 
 // Mock console.log to avoid noise in tests
-vi.spyOn(console, 'log').mockImplementation(() => {})
-vi.spyOn(console, 'warn').mockImplementation(() => {})
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
 
-describe('CodeGenerator', () => {
-  let generator: CodeGenerator
-  let mockFs: any
+describe("CodeGenerator", () => {
+  let generator: CodeGenerator;
+  let mockFs: any;
 
   beforeEach(() => {
-    generator = new CodeGenerator()
-    mockFs = vi.mocked(fs)
-    
+    generator = new CodeGenerator();
+    mockFs = vi.mocked(fs);
+
     // Reset all mocks
-    vi.clearAllMocks()
-    
+    vi.clearAllMocks();
+
     // Setup default mocks
-    mockFs.ensureDir.mockResolvedValue(undefined)
-    mockFs.writeFile.mockResolvedValue(undefined)
-    mockFs.readFile.mockResolvedValue('mock api client content')
-  })
+    mockFs.ensureDir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue("mock api client content");
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  describe('generate', () => {
-    it('should generate complete API with all components', async () => {
+  describe("generate", () => {
+    it("should generate complete API with all components", async () => {
       const config: GeneratorConfig = {
-        inputPath: '/path/to/openapi.json',
-        outputDir: '/output',
-        generateHooks: true
-      }
+        inputPath: "/path/to/openapi.json",
+        outputDir: "/output",
+        generateHooks: true,
+      };
 
       // Mock the parser to return a simple spec
       const mockParseFromFile = vi.fn().mockResolvedValue({
-        info: { title: 'Test API', version: '1.0.0' },
+        info: { title: "Test API", version: "1.0.0" },
         operations: [
           {
-            operationId: 'getUsers',
-            method: 'GET',
-            path: '/users',
-            tags: ['users'],
-            responses: { '200': { description: 'Success' } }
-          }
+            operationId: "getUsers",
+            method: "GET",
+            path: "/users",
+            tags: ["users"],
+            responses: { "200": { description: "Success" } },
+          },
         ],
         schemas: [
           {
-            name: 'User',
-            schema: { type: 'object', properties: { id: { type: 'string' } } }
-          }
+            name: "User",
+            schema: { type: "object", properties: { id: { type: "string" } } },
+          },
         ],
-        tags: ['users']
-      })
+        tags: ["users"],
+      });
 
       // Mock parser methods
-      vi.spyOn(generator['parser'], 'parseFromFile').mockImplementation(mockParseFromFile)
-      vi.spyOn(generator['parser'], 'generateClassName').mockReturnValue('UsersApi')
-      vi.spyOn(generator['parser'], 'generateOperationId').mockReturnValue('getUsers')
+      vi.spyOn(generator["parser"], "parseFromFile").mockImplementation(
+        mockParseFromFile,
+      );
+      vi.spyOn(generator["parser"], "generateClassName").mockReturnValue(
+        "UsersApi",
+      );
+      vi.spyOn(generator["parser"], "generateOperationId").mockReturnValue(
+        "getUsers",
+      );
 
-      await generator.generate(config)
+      await generator.generate(config);
 
       // Verify directories were created
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'models'))
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'endpoints'))
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'hooks'))
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "models"),
+      );
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "endpoints"),
+      );
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "hooks"),
+      );
 
       // Verify files were written
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'models', 'User.ts'),
-        expect.any(String)
-      )
+        path.join("/output", "models", "User.ts"),
+        expect.any(String),
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'models', 'index.ts'),
-        expect.any(String)
-      )
+        path.join("/output", "models", "index.ts"),
+        expect.any(String),
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'ApiClient.ts'),
-        expect.any(String)
-      )
+        path.join("/output", "ApiClient.ts"),
+        expect.any(String),
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'endpoints', 'UsersApi.ts'),
-        expect.any(String)
-      )
+        path.join("/output", "endpoints", "UsersApi.ts"),
+        expect.any(String),
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'hooks', 'users.ts'),
-        expect.any(String)
-      )
+        path.join("/output", "ApiSDK.ts"),
+        expect.any(String),
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'index.ts'),
-        expect.any(String)
-      )
-    })
+        path.join("/output", "hooks", "users.ts"),
+        expect.any(String),
+      );
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        path.join("/output", "index.ts"),
+        expect.any(String),
+      );
+    });
 
-    it('should skip hooks generation when disabled', async () => {
+    it("should skip hooks generation when disabled", async () => {
       const config: GeneratorConfig = {
-        inputPath: '/path/to/openapi.json',
-        outputDir: '/output',
-        generateHooks: false
-      }
+        inputPath: "/path/to/openapi.json",
+        outputDir: "/output",
+        generateHooks: false,
+      };
 
       const mockParseFromFile = vi.fn().mockResolvedValue({
-        info: { title: 'Test API', version: '1.0.0' },
+        info: { title: "Test API", version: "1.0.0" },
         operations: [],
         schemas: [],
-        tags: []
-      })
+        tags: [],
+      });
 
-      vi.spyOn(generator['parser'], 'parseFromFile').mockImplementation(mockParseFromFile)
+      vi.spyOn(generator["parser"], "parseFromFile").mockImplementation(
+        mockParseFromFile,
+      );
 
-      await generator.generate(config)
+      await generator.generate(config);
 
       // Hooks directory should still be created but not used
-      expect(mockFs.ensureDir).toHaveBeenCalledTimes(3) // models, endpoints, hooks
-      
+      expect(mockFs.ensureDir).toHaveBeenCalledTimes(3); // models, endpoints, hooks
+
       // Should not write hooks files
       expect(mockFs.writeFile).not.toHaveBeenCalledWith(
-        expect.stringContaining('hooks'),
-        expect.any(String)
-      )
-    })
+        expect.stringContaining("hooks"),
+        expect.any(String),
+      );
+    });
 
-    it('should handle URL input paths', async () => {
+    it("should handle URL input paths", async () => {
       const config: GeneratorConfig = {
-        inputPath: 'https://api.example.com/openapi.json',
-        outputDir: '/output'
-      }
+        inputPath: "https://api.example.com/openapi.json",
+        outputDir: "/output",
+      };
 
       const mockParseFromUrl = vi.fn().mockResolvedValue({
-        info: { title: 'Test API', version: '1.0.0' },
+        info: { title: "Test API", version: "1.0.0" },
         operations: [],
         schemas: [],
-        tags: []
-      })
+        tags: [],
+      });
 
-      vi.spyOn(generator['parser'], 'parseFromUrl').mockImplementation(mockParseFromUrl)
+      vi.spyOn(generator["parser"], "parseFromUrl").mockImplementation(
+        mockParseFromUrl,
+      );
 
-      await generator.generate(config)
+      await generator.generate(config);
 
-      expect(mockParseFromUrl).toHaveBeenCalledWith('https://api.example.com/openapi.json')
-    })
-  })
+      expect(mockParseFromUrl).toHaveBeenCalledWith(
+        "https://api.example.com/openapi.json",
+      );
+    });
+  });
 
-  describe('parseSpec', () => {
-    it('should parse from file for local paths', async () => {
-      const mockParseFromFile = vi.fn().mockResolvedValue({})
-      vi.spyOn(generator['parser'], 'parseFromFile').mockImplementation(mockParseFromFile)
+  describe("parseSpec", () => {
+    it("should parse from file for local paths", async () => {
+      const mockParseFromFile = vi.fn().mockResolvedValue({});
+      vi.spyOn(generator["parser"], "parseFromFile").mockImplementation(
+        mockParseFromFile,
+      );
 
-      await generator['parseSpec']('/path/to/spec.json')
+      await generator["parseSpec"]("/path/to/spec.json");
 
-      expect(mockParseFromFile).toHaveBeenCalledWith('/path/to/spec.json')
-    })
+      expect(mockParseFromFile).toHaveBeenCalledWith("/path/to/spec.json");
+    });
 
-    it('should parse from URL for HTTP paths', async () => {
-      const mockParseFromUrl = vi.fn().mockResolvedValue({})
-      vi.spyOn(generator['parser'], 'parseFromUrl').mockImplementation(mockParseFromUrl)
+    it("should parse from URL for HTTP paths", async () => {
+      const mockParseFromUrl = vi.fn().mockResolvedValue({});
+      vi.spyOn(generator["parser"], "parseFromUrl").mockImplementation(
+        mockParseFromUrl,
+      );
 
-      await generator['parseSpec']('http://example.com/spec.json')
+      await generator["parseSpec"]("http://example.com/spec.json");
 
-      expect(mockParseFromUrl).toHaveBeenCalledWith('http://example.com/spec.json')
-    })
+      expect(mockParseFromUrl).toHaveBeenCalledWith(
+        "http://example.com/spec.json",
+      );
+    });
 
-    it('should parse from URL for HTTPS paths', async () => {
-      const mockParseFromUrl = vi.fn().mockResolvedValue({})
-      vi.spyOn(generator['parser'], 'parseFromUrl').mockImplementation(mockParseFromUrl)
+    it("should parse from URL for HTTPS paths", async () => {
+      const mockParseFromUrl = vi.fn().mockResolvedValue({});
+      vi.spyOn(generator["parser"], "parseFromUrl").mockImplementation(
+        mockParseFromUrl,
+      );
 
-      await generator['parseSpec']('https://example.com/spec.json')
+      await generator["parseSpec"]("https://example.com/spec.json");
 
-      expect(mockParseFromUrl).toHaveBeenCalledWith('https://example.com/spec.json')
-    })
-  })
+      expect(mockParseFromUrl).toHaveBeenCalledWith(
+        "https://example.com/spec.json",
+      );
+    });
+  });
 
-  describe('createDirectories', () => {
-    it('should create all required directories', async () => {
-      await generator['createDirectories']('/output')
+  describe("createDirectories", () => {
+    it("should create all required directories", async () => {
+      await generator["createDirectories"]("/output");
 
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'models'))
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'endpoints'))
-      expect(mockFs.ensureDir).toHaveBeenCalledWith(path.join('/output', 'hooks'))
-    })
-  })
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "models"),
+      );
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "endpoints"),
+      );
+      expect(mockFs.ensureDir).toHaveBeenCalledWith(
+        path.join("/output", "hooks"),
+      );
+    });
+  });
 
-  describe('generateSchemas', () => {
-    it('should generate schema files and index', async () => {
+  describe("generateSchemas", () => {
+    it("should generate schema files and index", async () => {
       const schemas = [
-        { name: 'User', schema: { type: 'object' } },
-        { name: 'Post', schema: { type: 'object' } }
-      ]
+        { name: "User", schema: { type: "object" } },
+        { name: "Post", schema: { type: "object" } },
+      ];
 
       // Mock schema generator
-      vi.spyOn(generator['schemaGenerator'], 'generateSchemas').mockReturnValue([
-        { name: 'User', content: 'export const UserSchema = z.object({});', dependencies: [] },
-        { name: 'Post', content: 'export const PostSchema = z.object({});', dependencies: [] }
-      ])
-      vi.spyOn(generator['schemaGenerator'], 'generateIndexFile').mockReturnValue('export * from "./User";\nexport * from "./Post";')
+      vi.spyOn(generator["schemaGenerator"], "generateSchemas").mockReturnValue(
+        [
+          {
+            name: "User",
+            content: "export const UserSchema = z.object({});",
+            dependencies: [],
+          },
+          {
+            name: "Post",
+            content: "export const PostSchema = z.object({});",
+            dependencies: [],
+          },
+        ],
+      );
+      vi.spyOn(
+        generator["schemaGenerator"],
+        "generateIndexFile",
+      ).mockReturnValue('export * from "./User";\nexport * from "./Post";');
 
-      await generator['generateSchemas'](schemas, '/output')
+      await generator["generateSchemas"](schemas, "/output");
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'models', 'User.ts'),
-        'export const UserSchema = z.object({});'
-      )
+        path.join("/output", "models", "User.ts"),
+        "export const UserSchema = z.object({});",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'models', 'Post.ts'),
-        'export const PostSchema = z.object({});'
-      )
+        path.join("/output", "models", "Post.ts"),
+        "export const PostSchema = z.object({});",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'models', 'index.ts'),
-        'export * from "./User";\nexport * from "./Post";'
-      )
-    })
-  })
+        path.join("/output", "models", "index.ts"),
+        'export * from "./User";\nexport * from "./Post";',
+      );
+    });
+  });
 
-  describe('generateApiClient', () => {
-    it('should copy and format API client', async () => {
-      await generator['generateApiClient']('/output')
+  describe("generateApiClient", () => {
+    it("should copy and format API client", async () => {
+      await generator["generateApiClient"]("/output");
 
       expect(mockFs.readFile).toHaveBeenCalledWith(
-        expect.stringContaining('ApiClient.ts'),
-        'utf-8'
-      )
+        expect.stringContaining("ApiClient.ts"),
+        "utf-8",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'ApiClient.ts'),
-        'mock api client content'
-      )
-    })
-  })
+        path.join("/output", "ApiClient.ts"),
+        "mock api client content",
+      );
+    });
+  });
 
-  describe('generateEndpoints', () => {
-    it('should generate endpoint classes and index', async () => {
+  describe("generateEndpoints", () => {
+    it("should generate endpoint classes and index", async () => {
       const operations = [
-        { operationId: 'getUsers', method: 'GET', path: '/users', tags: ['users'] }
-      ]
-      const tags = ['users']
+        {
+          operationId: "getUsers",
+          method: "GET",
+          path: "/users",
+          tags: ["users"],
+        },
+      ];
+      const tags = ["users"];
 
-      vi.spyOn(generator['endpointGenerator'], 'generateEndpointClasses').mockReturnValue({
-        className: 'UsersApi',
-        content: 'export class UsersApi {}',
-        operations: []
-      })
-      vi.spyOn(generator['endpointGenerator'], 'generateIndexFile').mockReturnValue('export * from "./UsersApi";')
+      vi.spyOn(
+        generator["endpointGenerator"],
+        "generateEndpointClasses",
+      ).mockReturnValue({
+        className: "UsersApi",
+        content: "export class UsersApi {}",
+        operations: [],
+      });
+      vi.spyOn(
+        generator["endpointGenerator"],
+        "generateIndexFile",
+      ).mockReturnValue('export * from "./UsersApi";');
 
-      await generator['generateEndpoints'](operations, tags, '/output')
+      await generator["generateEndpoints"](operations, tags, "/output");
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'endpoints', 'UsersApi.ts'),
-        'export class UsersApi {}'
-      )
+        path.join("/output", "endpoints", "UsersApi.ts"),
+        "export class UsersApi {}",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'endpoints', 'index.ts'),
-        'export * from "./UsersApi";'
-      )
-    })
-  })
+        path.join("/output", "endpoints", "index.ts"),
+        'export * from "./UsersApi";',
+      );
+    });
+  });
 
-  describe('generateHooks', () => {
-    it('should generate hooks files and index', async () => {
+  describe("generateHooks", () => {
+    it("should generate hooks files and index", async () => {
       const operations = [
-        { operationId: 'getUsers', method: 'GET', path: '/users', tags: ['users'] }
-      ]
-      const tags = ['users']
+        {
+          operationId: "getUsers",
+          method: "GET",
+          path: "/users",
+          tags: ["users"],
+        },
+      ];
+      const tags = ["users"];
 
-      vi.spyOn(generator['parser'], 'generateClassName').mockReturnValue('UsersApi')
-      vi.spyOn(generator['parser'], 'generateOperationId').mockReturnValue('getUsers')
-      vi.spyOn(generator['endpointGenerator'], 'generateEndpointClasses').mockReturnValue({
-        className: 'UsersApi',
-        content: '',
-        operations: []
-      })
-      vi.spyOn(generator['hooksGenerator'], 'generateHooksForTag').mockReturnValue({
-        tag: 'users',
-        content: 'export function useGetUsers() {}',
-        hooks: []
-      })
-      vi.spyOn(generator['hooksGenerator'], 'generateQueryKeys').mockReturnValue('export const useGetUsersKey = () => [];')
-      vi.spyOn(generator['hooksGenerator'], 'generateIndexFile').mockReturnValue('export * from "./users";')
+      vi.spyOn(generator["parser"], "generateClassName").mockReturnValue(
+        "UsersApi",
+      );
+      vi.spyOn(generator["parser"], "generateOperationId").mockReturnValue(
+        "getUsers",
+      );
+      vi.spyOn(
+        generator["endpointGenerator"],
+        "generateEndpointClasses",
+      ).mockReturnValue({
+        className: "UsersApi",
+        content: "",
+        operations: [],
+      });
+      vi.spyOn(
+        generator["endpointGenerator"],
+        "generateMethod",
+      ).mockReturnValue({
+        name: "getUsers",
+        parameters: [],
+        returnType: "Promise<void>",
+        httpMethod: "GET",
+        path: "/users",
+        responseSchema: "z.unknown()",
+      });
+      vi.spyOn(
+        generator["hooksGenerator"],
+        "generateHooksForTag",
+      ).mockReturnValue({
+        tag: "users",
+        content: "export function useGetUsers() {}",
+        hooks: [],
+      });
+      vi.spyOn(
+        generator["hooksGenerator"],
+        "generateQueryKeys",
+      ).mockReturnValue("export const useGetUsersKey = () => [];");
+      vi.spyOn(
+        generator["hooksGenerator"],
+        "generateIndexFile",
+      ).mockReturnValue('export * from "./users";');
 
-      await generator['generateHooks'](operations, tags, '/output')
+      await generator["generateHooks"](operations, tags, "/output");
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'hooks', 'users.ts'),
-        'export function useGetUsers() {}'
-      )
+        path.join("/output", "hooks", "users.ts"),
+        "export function useGetUsers() {}",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'hooks', 'queryKeys.ts'),
-        'export const useGetUsersKey = () => [];'
-      )
+        path.join("/output", "hooks", "queryKeys.ts"),
+        "export const useGetUsersKey = () => [];",
+      );
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'hooks', 'index.ts'),
-        'export * from "./users";'
-      )
-    })
-  })
+        path.join("/output", "hooks", "index.ts"),
+        'export * from "./users";',
+      );
+    });
+  });
 
-  describe('generateIndexFiles', () => {
-    it('should generate main index file with hooks', async () => {
+  describe("generateIndexFiles", () => {
+    it("should generate main index file with hooks", async () => {
       const config: GeneratorConfig = {
-        inputPath: '/input',
-        outputDir: '/output',
-        generateHooks: true
-      }
+        inputPath: "/input",
+        outputDir: "/output",
+        generateHooks: true,
+      };
 
-      await generator['generateIndexFiles']([], [], config)
+      await generator["generateIndexFiles"]([], [], config);
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'index.ts'),
-        expect.stringContaining("export * from './hooks';")
-      )
-    })
+        path.join("/output", "index.ts"),
+        expect.stringContaining("export * from './ApiSDK';"),
+      );
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        path.join("/output", "index.ts"),
+        expect.stringContaining("export * from './hooks';"),
+      );
+    });
 
-    it('should generate main index file without hooks', async () => {
+    it("should generate main index file without hooks", async () => {
       const config: GeneratorConfig = {
-        inputPath: '/input',
-        outputDir: '/output',
-        generateHooks: false
-      }
+        inputPath: "/input",
+        outputDir: "/output",
+        generateHooks: false,
+      };
 
-      await generator['generateIndexFiles']([], [], config)
+      await generator["generateIndexFiles"]([], [], config);
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
-        path.join('/output', 'index.ts'),
-        expect.not.stringContaining("export * from './hooks';")
-      )
-    })
-  })
+        path.join("/output", "index.ts"),
+        expect.stringContaining("export * from './ApiSDK';"),
+      );
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        path.join("/output", "index.ts"),
+        expect.not.stringContaining("export * from './hooks';"),
+      );
+    });
+  });
 
-  describe('formatCode', () => {
-    it('should format code successfully', async () => {
-      const { format } = await import('prettier')
-      vi.mocked(format).mockReturnValue('formatted code')
+  describe("formatCode", () => {
+    it("should format code successfully", async () => {
+      const { format } = await import("prettier");
+      vi.mocked(format).mockReturnValue("formatted code");
 
-      const result = await generator['formatCode']('unformatted code')
+      const result = await generator["formatCode"]("unformatted code");
 
-      expect(result).toBe('formatted code')
-      expect(format).toHaveBeenCalledWith('unformatted code', {
-        parser: 'typescript',
+      expect(result).toBe("formatted code");
+      expect(format).toHaveBeenCalledWith("unformatted code", {
+        parser: "typescript",
         singleQuote: true,
-        trailingComma: 'es5',
+        trailingComma: "es5",
         tabWidth: 2,
         semi: true,
-      })
-    })
+      });
+    });
 
-    it('should handle formatting errors gracefully', async () => {
-      const { format } = await import('prettier')
+    it("should handle formatting errors gracefully", async () => {
+      const { format } = await import("prettier");
       vi.mocked(format).mockImplementation(() => {
-        throw new Error('Formatting error')
-      })
+        throw new Error("Formatting error");
+      });
 
-      const result = await generator['formatCode']('unformatted code')
+      const result = await generator["formatCode"]("unformatted code");
 
-      expect(result).toBe('unformatted code')
+      expect(result).toBe("unformatted code");
       // Console.warn was called (we can't check the exact message due to mocking issues)
-    })
-  })
-})
+    });
+  });
+});

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -1,10 +1,11 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import { OpenAPIParser } from '../utils/openapi-parser';
-import { SchemaGenerator } from './schema-generator';
-import { EndpointGenerator } from './endpoint-generator';
-import { HooksGenerator } from './hooks-generator';
-import { format } from 'prettier';
+import * as fs from "fs-extra";
+import * as path from "path";
+import { OpenAPIParser } from "../utils/openapi-parser";
+import { SchemaGenerator } from "./schema-generator";
+import { EndpointGenerator } from "./endpoint-generator";
+import { HooksGenerator } from "./hooks-generator";
+import { SdkGenerator } from "./sdk-generator";
+import { format } from "prettier";
 
 export interface GeneratorConfig {
   inputPath: string;
@@ -20,51 +21,57 @@ export class CodeGenerator {
   private schemaGenerator: SchemaGenerator;
   private endpointGenerator: EndpointGenerator;
   private hooksGenerator: HooksGenerator;
+  private sdkGenerator: SdkGenerator;
 
   constructor() {
     this.parser = new OpenAPIParser();
     this.schemaGenerator = new SchemaGenerator();
     this.endpointGenerator = new EndpointGenerator(this.parser);
     this.hooksGenerator = new HooksGenerator();
+    this.sdkGenerator = new SdkGenerator();
   }
 
   async generate(config: GeneratorConfig): Promise<void> {
-    console.log('🚀 Starting OpenAPI code generation...');
-    
+    console.log("🚀 Starting OpenAPI code generation...");
+
     // Parse OpenAPI spec
-    console.log('📖 Parsing OpenAPI specification...');
+    console.log("📖 Parsing OpenAPI specification...");
     const spec = await this.parseSpec(config.inputPath);
-    
+
     // Create output directories
     await this.createDirectories(config.outputDir);
-    
+
     // Generate schemas (Zod models)
-    console.log('🔨 Generating Zod schemas...');
+    console.log("🔨 Generating Zod schemas...");
     await this.generateSchemas(spec.schemas, config.outputDir);
-    
+
     // Generate API client base
-    console.log('🌐 Generating base API client...');
+    console.log("🌐 Generating base API client...");
     await this.generateApiClient(config.outputDir);
-    
+
     // Generate endpoint classes
-    console.log('⚡ Generating endpoint classes...');
+    console.log("⚡ Generating endpoint classes...");
     await this.generateEndpoints(spec.operations, spec.tags, config.outputDir);
-    
+
+    // Generate SDK wrapper
+    console.log("📚 Generating SDK wrapper...");
+    await this.generateSdk(spec.tags, config.outputDir);
+
     // Generate React Query hooks (if enabled)
     if (config.generateHooks !== false) {
-      console.log('🪝 Generating React Query hooks...');
+      console.log("🪝 Generating React Query hooks...");
       await this.generateHooks(spec.operations, spec.tags, config.outputDir);
     }
-    
+
     // Generate index files
-    console.log('📦 Generating index files...');
+    console.log("📦 Generating index files...");
     await this.generateIndexFiles(spec.schemas, spec.tags, config);
-    
-    console.log('✅ Code generation completed successfully!');
+
+    console.log("✅ Code generation completed successfully!");
   }
 
   private async parseSpec(inputPath: string) {
-    if (inputPath.startsWith('http')) {
+    if (inputPath.startsWith("http")) {
       return await this.parser.parseFromUrl(inputPath);
     } else {
       return await this.parser.parseFromFile(inputPath);
@@ -73,9 +80,9 @@ export class CodeGenerator {
 
   private async createDirectories(outputDir: string): Promise<void> {
     const dirs = [
-      path.join(outputDir, 'models'),
-      path.join(outputDir, 'endpoints'),
-      path.join(outputDir, 'hooks'),
+      path.join(outputDir, "models"),
+      path.join(outputDir, "endpoints"),
+      path.join(outputDir, "hooks"),
     ];
 
     for (const dir of dirs) {
@@ -83,8 +90,11 @@ export class CodeGenerator {
     }
   }
 
-  private async generateSchemas(schemas: any[], outputDir: string): Promise<void> {
-    const modelsDir = path.join(outputDir, 'models');
+  private async generateSchemas(
+    schemas: any[],
+    outputDir: string,
+  ): Promise<void> {
+    const modelsDir = path.join(outputDir, "models");
     const generatedSchemas = this.schemaGenerator.generateSchemas(schemas);
 
     for (const schema of generatedSchemas) {
@@ -95,32 +105,35 @@ export class CodeGenerator {
 
     // Generate models index file
     const indexContent = this.schemaGenerator.generateIndexFile(
-      generatedSchemas.map(s => s.name)
+      generatedSchemas.map((s) => s.name),
     );
     const formattedIndex = await this.formatCode(indexContent);
-    await fs.writeFile(path.join(modelsDir, 'index.ts'), formattedIndex);
+    await fs.writeFile(path.join(modelsDir, "index.ts"), formattedIndex);
   }
 
   private async generateApiClient(outputDir: string): Promise<void> {
     // Copy the base ApiClient to the output directory
-    const apiClientPath = path.join(__dirname, '../../src/ApiClient.ts');
-    const outputPath = path.join(outputDir, 'ApiClient.ts');
-    
-    const content = await fs.readFile(apiClientPath, 'utf-8');
+    const apiClientPath = path.join(__dirname, "../../src/ApiClient.ts");
+    const outputPath = path.join(outputDir, "ApiClient.ts");
+
+    const content = await fs.readFile(apiClientPath, "utf-8");
     const formattedContent = await this.formatCode(content);
     await fs.writeFile(outputPath, formattedContent);
   }
 
   private async generateEndpoints(
-    operations: any[], 
-    tags: string[], 
-    outputDir: string
+    operations: any[],
+    tags: string[],
+    outputDir: string,
   ): Promise<void> {
-    const endpointsDir = path.join(outputDir, 'endpoints');
+    const endpointsDir = path.join(outputDir, "endpoints");
     const generatedClasses: string[] = [];
 
     for (const tag of tags) {
-      const endpoint = this.endpointGenerator.generateEndpointClasses(operations, tag);
+      const endpoint = this.endpointGenerator.generateEndpointClasses(
+        operations,
+        tag,
+      );
       const filePath = path.join(endpointsDir, `${endpoint.className}.ts`);
       const formattedContent = await this.formatCode(endpoint.content);
       await fs.writeFile(filePath, formattedContent);
@@ -128,35 +141,48 @@ export class CodeGenerator {
     }
 
     // Generate endpoints index file
-    const indexContent = this.endpointGenerator.generateIndexFile(generatedClasses);
+    const indexContent =
+      this.endpointGenerator.generateIndexFile(generatedClasses);
     const formattedIndex = await this.formatCode(indexContent);
-    await fs.writeFile(path.join(endpointsDir, 'index.ts'), formattedIndex);
+    await fs.writeFile(path.join(endpointsDir, "index.ts"), formattedIndex);
+  }
+
+  private async generateSdk(tags: string[], outputDir: string): Promise<void> {
+    const classNames = tags.map((tag) => this.parser.generateClassName(tag));
+    const sdkContent = this.sdkGenerator.generateSdk(classNames);
+    const formatted = await this.formatCode(sdkContent);
+    await fs.writeFile(path.join(outputDir, "ApiSDK.ts"), formatted);
   }
 
   private async generateHooks(
-    operations: any[], 
-    tags: string[], 
-    outputDir: string
+    operations: any[],
+    tags: string[],
+    outputDir: string,
   ): Promise<void> {
-    const hooksDir = path.join(outputDir, 'hooks');
+    const hooksDir = path.join(outputDir, "hooks");
 
     for (const tag of tags) {
-      const tagOperations = operations.filter(op => op.tags?.includes(tag) || !op.tags?.length);
+      const tagOperations = operations.filter(
+        (op) => op.tags?.includes(tag) || !op.tags?.length,
+      );
       const className = this.parser.generateClassName(tag);
-      
+
       // Generate the actual endpoint methods info
-      const endpoint = this.endpointGenerator.generateEndpointClasses(operations, tag);
-      
+      const endpoint = this.endpointGenerator.generateEndpointClasses(
+        operations,
+        tag,
+      );
+
       // Use the endpoint generator to create the actual methods
-      const methods = tagOperations.map(operation => {
+      const methods = tagOperations.map((operation) => {
         return this.endpointGenerator.generateMethod(operation);
       });
 
       const hooksFile = this.hooksGenerator.generateHooksForTag(
-        tagOperations, 
-        tag, 
+        tagOperations,
+        tag,
         className,
-        methods
+        methods,
       );
 
       const filePath = path.join(hooksDir, `${tag}.ts`);
@@ -167,41 +193,45 @@ export class CodeGenerator {
     // Generate query keys file
     const queryKeysContent = this.hooksGenerator.generateQueryKeys(operations);
     const formattedQueryKeys = await this.formatCode(queryKeysContent);
-    await fs.writeFile(path.join(hooksDir, 'queryKeys.ts'), formattedQueryKeys);
+    await fs.writeFile(path.join(hooksDir, "queryKeys.ts"), formattedQueryKeys);
 
     // Generate hooks index file
     const indexContent = this.hooksGenerator.generateIndexFile(tags);
     const formattedIndex = await this.formatCode(indexContent);
-    await fs.writeFile(path.join(hooksDir, 'index.ts'), formattedIndex);
+    await fs.writeFile(path.join(hooksDir, "index.ts"), formattedIndex);
   }
 
   private async generateIndexFiles(
-    schemas: any[], 
-    tags: string[], 
-    config: GeneratorConfig
+    schemas: any[],
+    tags: string[],
+    config: GeneratorConfig,
   ): Promise<void> {
     const mainIndexContent = `// Generated API Client
 export * from './ApiClient';
 export * from './models';
 export * from './endpoints';
-${config.generateHooks !== false ? "export * from './hooks';" : ''}
+export * from './ApiSDK';
+${config.generateHooks !== false ? "export * from './hooks';" : ""}
 `;
 
     const formattedMainIndex = await this.formatCode(mainIndexContent);
-    await fs.writeFile(path.join(config.outputDir, 'index.ts'), formattedMainIndex);
+    await fs.writeFile(
+      path.join(config.outputDir, "index.ts"),
+      formattedMainIndex,
+    );
   }
 
   private async formatCode(code: string): Promise<string> {
     try {
       return format(code, {
-        parser: 'typescript',
+        parser: "typescript",
         singleQuote: true,
-        trailingComma: 'es5',
+        trailingComma: "es5",
         tabWidth: 2,
         semi: true,
       });
     } catch (error) {
-      console.warn('⚠️  Failed to format code, using unformatted version');
+      console.warn("⚠️  Failed to format code, using unformatted version");
       return code;
     }
   }

--- a/src/generator/sdk-generator.ts
+++ b/src/generator/sdk-generator.ts
@@ -1,0 +1,27 @@
+export class SdkGenerator {
+  generateSdk(classNames: string[]): string {
+    const imports = classNames
+      .map((name) => `import { ${name} } from "./endpoints/${name}";`)
+      .join("\n");
+
+    const properties = classNames
+      .map((name) => {
+        const prop = this.toCamelCase(name); // convert to camelCase
+        return `  public ${prop}: ${name};`;
+      })
+      .join("\n");
+
+    const assignments = classNames
+      .map((name) => {
+        const prop = this.toCamelCase(name);
+        return `    this.${prop} = new ${name}(config);`;
+      })
+      .join("\n");
+
+    return `${imports}\nimport type { ApiClientConfig } from "./ApiClient";\n\nexport class ApiSDK {\n${properties}\n\n  constructor(config: ApiClientConfig) {\n${assignments}\n  }\n}\n`;
+  }
+
+  private toCamelCase(str: string): string {
+    return str.charAt(0).toLowerCase() + str.slice(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,26 @@
 // Main library exports
-export { CodeGenerator } from './generator';
-export { OpenAPIParser } from './utils/openapi-parser';
-export { SchemaGenerator } from './generator/schema-generator';
-export { EndpointGenerator } from './generator/endpoint-generator';
-export { HooksGenerator } from './generator/hooks-generator';
-export { ApiClient } from './ApiClient';
+export { CodeGenerator } from "./generator";
+export { OpenAPIParser } from "./utils/openapi-parser";
+export { SchemaGenerator } from "./generator/schema-generator";
+export { EndpointGenerator } from "./generator/endpoint-generator";
+export { HooksGenerator } from "./generator/hooks-generator";
+export { SdkGenerator } from "./generator/sdk-generator";
+export { ApiClient } from "./ApiClient";
 
 // Type exports
-export type { GeneratorConfig } from './generator';
-export type { ParsedOperation, ParsedSchema, ParsedSpec } from './utils/openapi-parser';
-export type { GeneratedSchema } from './generator/schema-generator';
-export type { GeneratedEndpoint, GeneratedMethod } from './generator/endpoint-generator';
-export type { GeneratedHook, GeneratedHooksFile } from './generator/hooks-generator';
-export type { ApiClientConfig } from './ApiClient';
+export type { GeneratorConfig } from "./generator";
+export type {
+  ParsedOperation,
+  ParsedSchema,
+  ParsedSpec,
+} from "./utils/openapi-parser";
+export type { GeneratedSchema } from "./generator/schema-generator";
+export type {
+  GeneratedEndpoint,
+  GeneratedMethod,
+} from "./generator/endpoint-generator";
+export type {
+  GeneratedHook,
+  GeneratedHooksFile,
+} from "./generator/hooks-generator";
+export type { ApiClientConfig } from "./ApiClient";


### PR DESCRIPTION
## Summary
- introduce `SdkGenerator` that builds an `ApiSDK` class wrapping endpoint clients
- generate the new SDK file and export it from the main index
- update hook generation to use a shared `ApiSDK` instance
- document new SDK usage in README
- adjust tests for new behaviour and cover SDK creation

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_683d9bff8e0883339d4060d934313095