### PR TITLE
Fix CLI name references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@shooks/query-gen",
+  "name": "openapi-gen",
   "version": "0.0.1",
   "description": "Custom OpenAPI Code Generator with Zod and React Query Hooks",
   "main": "dist/index.js",
   "bin": {
-    "query-gen": "dist/cli.js"
+    "openapi-gen": "dist/cli.js"
   },
   "packageManager": "pnpm@10.11.0",
   "files": [
@@ -25,8 +25,8 @@
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write src",
     "prepublishOnly": "pnpm run build && pnpm run test:run",
-    "example": "query-gen generate -i openapi.json -o generated",
-    "example-dev": "query-gen generate -i openapi.json -o generated --base-url http://localhost:3000/api"
+    "example": "openapi-gen generate -i openapi.json -o generated",
+    "example-dev": "openapi-gen generate -i openapi.json -o generated --base-url http://localhost:3000/api"
   },
   "keywords": [
     "openapi",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra';
 const program = new Command();
 
 program
-  .name('query-gen')
+  .name('openapi-gen')
   .description('Custom OpenAPI Code Generator with Zod and React Query Hooks')
   .version('0.0.1');
 


### PR DESCRIPTION
## Summary
- standardize CLI to `openapi-gen`

## Testing
- `pnpm test:run` *(fails: Cannot read properties of undefined (reading '200'))*

------
https://chatgpt.com/codex/tasks/task_e_683d9c0773b483339f8327f3945068b2