### PR TITLE
Improve generator type safety

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -22,9 +22,9 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      body?: any;
+      body?: unknown;
       bodySchema?: z.ZodTypeAny;
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {
@@ -99,7 +99,7 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {
@@ -110,9 +110,9 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      body?: any;
+      body?: unknown;
       bodySchema?: z.ZodTypeAny;
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {
@@ -123,9 +123,9 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      body?: any;
+      body?: unknown;
       bodySchema?: z.ZodTypeAny;
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {
@@ -136,9 +136,9 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      body?: any;
+      body?: unknown;
       bodySchema?: z.ZodTypeAny;
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {
@@ -149,7 +149,7 @@ export class ApiClient {
     path: string,
     responseSchema: Schema,
     options: {
-      queryParams?: Record<string, any>;
+      queryParams?: Record<string, unknown>;
       headers?: Record<string, string>;
     } = {}
   ): Promise<z.infer<Schema>> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -219,7 +219,11 @@ program
 
       // Create package.json scripts
       const packagePath = path.join(targetDir, 'package.json');
-      let packageJson: any = {};
+      interface PackageJson {
+        scripts?: Record<string, string>;
+        [key: string]: unknown;
+      }
+      let packageJson: PackageJson = {};
       
       if (await fs.pathExists(packagePath)) {
         packageJson = await fs.readJSON(packagePath);

--- a/src/generator/endpoint-generator.test.ts
+++ b/src/generator/endpoint-generator.test.ts
@@ -300,10 +300,26 @@ describe('EndpointGenerator', () => {
       }
 
       const result = generator.generateEndpointClasses([operation], 'default')
-      expect(result.content).toContain('tags?: any[]')
+      expect(result.content).toContain('tags?: unknown[]')
     })
 
-    it('should default to any for unknown parameter types', () => {
+    it('should handle typed array parameters', () => {
+      const operation: ParsedOperation = {
+        method: 'GET',
+        path: '/users',
+        parameters: [{
+          name: 'tags',
+          in: 'query',
+          schema: { type: 'array', items: { type: 'string' } }
+        }],
+        responses: { '200': { description: 'Success' } }
+      }
+
+      const result = generator.generateEndpointClasses([operation], 'default')
+      expect(result.content).toContain('tags?: string[]')
+    })
+
+    it('should default to unknown for unknown parameter types', () => {
       const operation: ParsedOperation = {
         method: 'GET',
         path: '/users',
@@ -316,7 +332,7 @@ describe('EndpointGenerator', () => {
       }
 
       const result = generator.generateEndpointClasses([operation], 'default')
-      expect(result.content).toContain('custom?: any')
+      expect(result.content).toContain('custom?: unknown')
     })
   })
 
@@ -378,7 +394,7 @@ describe('EndpointGenerator', () => {
       expect(result.content).not.toContain('bodySchema:')
     })
 
-    it('should handle inline schemas returning z.unknown()', () => {
+    it('should handle inline object schemas', () => {
       const operation: ParsedOperation = {
         method: 'GET',
         path: '/users',
@@ -398,8 +414,8 @@ describe('EndpointGenerator', () => {
       }
 
       const result = generator.generateEndpointClasses([operation], 'default')
-      // This tests the inline schema case (line 192)
-      expect(result.content).toContain('z.unknown()')
+      expect(result.content).toContain('z.object')
+      expect(result.content).toContain('id: z.string()')
     })
 
     it('should handle type inference for unknown schemas', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export { SdkGenerator } from "./generator/sdk-generator";
 export { ApiClient } from "./ApiClient";
 
 // Type exports
-export type { GeneratorConfig } from "./generator";
+export type { GeneratorConfig, GenerationResult } from "./generator";
 export type {
   ParsedOperation,
   ParsedSchema,


### PR DESCRIPTION
## Summary
- use PrettierOptions for generator config
- strictly type internal generator methods using ParsedSpec
- update imports to use explicit types
- generate nested schema references for arrays and objects

## Testing
- `npm run typecheck`
- `npm run test:run`
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683e3e707a988333999353449f3f8f2e