### PR TITLE
Enhance OpenAPI parser and generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A powerful TypeScript code generator that creates type-safe API clients from Ope
 - 🎯 **DRY design** with minimal code duplication
 - 🔧 **Customizable** with flexible configuration options
 - 📖 **Well-documented** generated code
+- 🌐 **Automatic base URL selection** from OpenAPI servers
+- 🔐 **Security headers** applied using security schemes
 
 ## Installation
 
@@ -319,7 +321,7 @@ await generator.generate({
 
 ## OpenAPI Support
 
-This generator supports OpenAPI 3.0+ specifications and handles:
+This generator supports OpenAPI 2.0, 3.0 and 3.1 specifications and handles:
 
 - ✅ All primitive types (string, number, boolean, array, object)
 - ✅ String formats (email, uri, uuid, date-time, etc.)
@@ -330,6 +332,7 @@ This generator supports OpenAPI 3.0+ specifications and handles:
 - ✅ String validation with length and pattern constraints
 - ✅ Union types (oneOf, anyOf)
 - ✅ Intersection types (allOf)
+- ✅ Nullable fields handled automatically
 - ✅ Reference resolution ($ref)
 - ✅ Path parameters
 - ✅ Query parameters

--- a/src/generator/endpoint-generator.test.ts
+++ b/src/generator/endpoint-generator.test.ts
@@ -95,9 +95,34 @@ describe('EndpointGenerator', () => {
       }
 
       const result = generator.generateEndpointClasses([operation], 'default')
-      
+
       expect(result.content).toContain('limit?: number')
       expect(result.content).toContain('queryParams: { limit }')
+    })
+
+    it('should preserve parameter style options', () => {
+      const operation: ParsedOperation = {
+        method: 'GET',
+        path: '/users',
+        parameters: [{
+          name: 'ids',
+          in: 'query',
+          required: false,
+          schema: { type: 'array' },
+          style: 'form',
+          explode: true,
+          allowReserved: true,
+          example: [1,2]
+        }],
+        responses: { '200': { description: 'ok' } }
+      }
+
+      const method = generator.generateMethod(operation)
+      const param = method.parameters[0]
+      expect(param.style).toBe('form')
+      expect(param.explode).toBe(true)
+      expect(param.allowReserved).toBe(true)
+      expect(param.example).toEqual([1,2])
     })
 
     it('should generate method with request body', () => {

--- a/src/generator/endpoint-generator.ts
+++ b/src/generator/endpoint-generator.ts
@@ -12,6 +12,10 @@ export interface MethodParameter {
   type: string;
   required: boolean;
   location: 'path' | 'query' | 'header' | 'body';
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+  example?: any;
 }
 
 export interface GeneratedMethod {
@@ -110,9 +114,13 @@ ${methods.map(method => this.generateMethodCode(method)).join('\n\n')}
         if (!seenParams.has(paramName)) {
           const parameter: MethodParameter = {
             name: paramName,
-            type: this.getParameterType(param.schema),
-            required: param.required || false,
-            location: param.in as 'query' | 'header',
+            type: this.getParameterType((param as any).schema),
+            required: (param as any).required || false,
+            location: (param as any).in as 'query' | 'header',
+            style: (param as any).style,
+            explode: (param as any).explode,
+            allowReserved: (param as any).allowReserved,
+            example: (param as any).example,
           };
           parameters.push(parameter);
           seenParams.add(paramName);

--- a/src/generator/schema-generator.test.ts
+++ b/src/generator/schema-generator.test.ts
@@ -150,6 +150,31 @@ describe('SchemaGenerator', () => {
       expect(result[0].content).toContain('z.union([z.string(), z.boolean()])')
     })
 
+    it('should handle nullable schemas', () => {
+      const schemas: ParsedSchema[] = [{
+        name: 'NullableName',
+        schema: {
+          type: 'string',
+          nullable: true
+        }
+      }]
+
+      const result = generator.generateSchemas(schemas)
+      expect(result[0].content).toContain('z.union([z.string(), z.null()])')
+    })
+
+    it('should handle type array with null', () => {
+      const schemas: ParsedSchema[] = [{
+        name: 'MaybeNumber',
+        schema: {
+          type: ['number', 'null'] as any
+        }
+      }]
+
+      const result = generator.generateSchemas(schemas)
+      expect(result[0].content).toContain('z.union([z.number(), z.null()])')
+    })
+
     it('should handle allOf schemas', () => {
       const schemas: ParsedSchema[] = [{
         name: 'Combined',

--- a/src/utils/openapi-parser.test.ts
+++ b/src/utils/openapi-parser.test.ts
@@ -224,6 +224,24 @@ describe('OpenAPIParser', () => {
     })
   })
 
+  describe('version and servers', () => {
+    it('should detect v2 specs and convert servers', async () => {
+      const spec: any = {
+        swagger: '2.0',
+        info: { title: 'V2', version: '1' },
+        host: 'api.example.com',
+        basePath: '/v2',
+        schemes: ['https'],
+        paths: { '/ping': { get: { responses: { '200': { description: 'ok' } } } } },
+        securityDefinitions: { ApiKeyAuth: { type: 'apiKey', name: 'X-API', in: 'header' } },
+      };
+
+      const result = await parser.parseFromObject(spec);
+      expect(result.version).toBe('2');
+      expect(result.servers?.[0].url).toBe('https://api.example.com/v2');
+    });
+  })
+
   describe('error handling', () => {
     it('should throw error when no spec is loaded', () => {
       // Create a new parser that hasn't loaded any spec


### PR DESCRIPTION
## Summary
- support OpenAPI v2/v3/v3.1 in parser
- convert v2 specs to v3
- retain servers, security schemes and version info
- handle nullable schemas in generator
- include parameter style metadata in generated methods
- auto-select server base URL and apply apiKey auth
- document new capabilities
- add regression tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e493281fc83338cbf9c669ec6cb60