### PR TITLE
Move inline schema script into examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ This generator supports OpenAPI 3.0+ specifications and handles:
 - ✅ Request body validation
 - ✅ Multiple response types
 
+## Examples
+
+See `examples/inline-schema-example.ts` for a standalone script demonstrating how
+to generate a method and React Query hook from an inline object schema.
+
 ## Contributing
 
 1. Fork the repository

--- a/examples/inline-schema-example.ts
+++ b/examples/inline-schema-example.ts
@@ -1,6 +1,6 @@
-import { EndpointGenerator } from './src/generator/endpoint-generator';
-import { HooksGenerator } from './src/generator/hooks-generator';
-import { OpenAPIParser } from './src/utils/openapi-parser';
+import { EndpointGenerator } from '../src/generator/endpoint-generator';
+import { HooksGenerator } from '../src/generator/hooks-generator';
+import { OpenAPIParser } from '../src/utils/openapi-parser';
 
 // Test case showing the issue with inline object schemas
 const testOperation = {


### PR DESCRIPTION
## Summary
- move `test-inline-schema.ts` to `examples/inline-schema-example.ts`
- link example in README

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_6840528ee3508333a8d7c217366b5807